### PR TITLE
allValid should validate all elements and not stop on first invalid

### DIFF
--- a/jquery.h5validate.js
+++ b/jquery.h5validate.js
@@ -153,8 +153,7 @@
 			allValid: function (settings) {
 				var valid = true;
 				$(this).find(settings.allValidSelectors).each(function() {
-					valid = $(this).h5Validate('isValid');
-					return valid;
+					valid = $(this).h5Validate('isValid') && valid;
 				});
 				return valid;
 			},


### PR DESCRIPTION
Changing the loop of the allValid method to validate all elements instead of all until the first one which is invalid, so that in a scenario like:

``` javascript
form.submit(function(event) {
if (!form.h5Validate('allValid')) {
event.preventDefault();
}
});
```

all invalid fields get marked / highlighted
