### PR TITLE
Allow allValid options to override default settings

### DIFF
--- a/jquery.h5validate.js
+++ b/jquery.h5validate.js
@@ -186,7 +186,8 @@
 					getValidity = function getValidity(e, data) {
 						data.e = e;
 						formValidity.push(data);
-					};
+					},
+					settings = $.extend({}, settings, options); // allow options to override settings
 
 				options = options || {};
 


### PR DESCRIPTION
We had a case where we needed allValid to validate different sets of elements, so we needed to change allValidSelectors on the fly.

Figured this provides a little more flexibility, so you can override settings from the allValid options.
