### PR TITLE
Added validation when submitting an h5Validate enabled form

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,11 @@
 			<p><em>Note: The click event isn't just for the mouse. It will trigger for keyboard and touch screen interactions, too.</em></p>
 			<code class="block">click: true</code>
 		</dd>
+		<dt>submit</dt><dd><p>(Event) When enabled, prevents submission of a form that has invalid fields. Performs validation on all fields. If any fields are invalid, it moves focus to the first one. Defaults:</p>
+			<code class="block">submit: true,<br />
+				validateOnSubmit: true,<br />
+				focusFirstInvalidElementOnSubmit: true</code>
+		</dd>
 
 		<section>
 			<h2>Event API</h2>

--- a/test/test.h5validate.js
+++ b/test/test.h5validate.js
@@ -102,6 +102,272 @@
 			$form.h5Validate('allValid');
 		});
 
+		module('Submit handler');
+
+		test('Disabled', 1, function () {
+			var $form = $('<form />', {
+					id: 'submitTest'
+				}),
+				$input1;
+
+			$('<input required id="checked-at-submit-1" value="abc123" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$input1 = $('#checked-at-submit-1');
+
+			$form.h5Validate({
+				submit: false
+			});
+
+			$input1.bind('validated', function (event, data) {
+				fail('Validation should not run.');
+			});
+
+			$form.submit(function(evt){
+
+				ok(evt.isDefaultPrevented() !== true, 'Default should not be prevented, despite the invalid fields.');
+
+				// Make sure not to submit in the test code
+				evt.preventDefault();
+				return false;
+			});
+
+			$form.submit();
+
+			$form.remove();
+		});
+
+		test('Enabled, all fields valid', 2, function () {
+			var $form = $('<form />', {
+					id: 'submitTest'
+				}),
+				$input1;
+
+			$('<input required id="checked-at-submit-1" value="abc123" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$input1 = $('#checked-at-submit-1');
+
+			$form.h5Validate();
+
+			$input1.bind('validated', function (event, data) {
+				ok(data, 'Validation triggered on submit. #' +  data.element.id);
+			});
+
+			$form.submit(function(evt) {
+
+				ok(!evt.isDefaultPrevented(), 'Default should not be prevented, all fields are valid.');
+
+				// Make sure not to submit in the test code
+				evt.preventDefault();
+				return false;
+			});
+
+			$form.submit();
+
+			$form.remove();
+		});
+
+		test('Enabled, some fields invalid', 2, function () {
+			var $form = $('<form />', {
+					id: 'submitTest'
+				}),
+				$input1;
+
+			$('<input required id="checked-at-submit-1" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$input1 = $('#checked-at-submit-1');
+
+			$form.h5Validate();
+
+			$input1.bind('validated', function (event, data) {
+				ok(data, 'Validation triggered on submit. #' +  data.element.id);
+			});
+
+			$form.submit(function(evt) {
+
+				ok(evt.isDefaultPrevented(), 'Default should be prevented, at least one field is invalid.');
+
+				// Make sure not to submit in the test code
+				evt.preventDefault();
+				return false;
+			});
+
+			$form.submit();
+
+			$form.remove();
+		});
+
+		test('Submit time validation disabled', 1, function () {
+			var $form = $('<form />', {
+					id: 'submitTest'
+				}),
+				$input1;
+
+			$('<input required id="checked-at-submit-1" value="abc123" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$input1 = $('#checked-at-submit-1');
+
+			$form.h5Validate({
+					validateOnSubmit: false
+				});
+
+			$input1.bind('validated', function (event, data) {
+				ok(false, 'Validation should not run. #' +  data.element.id);
+			});
+
+			$form.submit(function(evt) {
+
+				equal(evt.isDefaultPrevented(), true, 'Form submission should be prevented since validation has not been performed.');
+
+				// Make sure not to submit in the test code
+				evt.preventDefault();
+				return false;
+			});
+
+			$form.submit();
+
+			$form.remove();
+		});
+
+		test('Submit time validation disabled', 2, function () {
+			var $form = $('<form />', {
+					id: 'submitTest'
+				}),
+				$input1,
+				validationShouldRun = false;
+
+			$('<input required id="checked-at-submit-1" value="abc123" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$input1 = $('#checked-at-submit-1');
+
+			$form.h5Validate({
+					validateOnSubmit: false
+				});
+
+			$input1.bind('validated', function (event, data) {
+				if(validationShouldRun) {
+					ok(true, 'Validation should run when called manually. #' +  data.element.id);
+				} else {
+					ok(false, 'Validation should not run on submit. #' +  data.element.id);
+				}
+			});
+
+			$form.submit(function(evt) {
+
+				equal(evt.isDefaultPrevented(), false, 'Form submission should not be prevented since validation has been performed manually.');
+
+				// Make sure not to submit in the test code
+				evt.preventDefault();
+				return false;
+			});
+
+			validationShouldRun = true;
+			$form.h5Validate('allValid');
+
+			validationShouldRun = false;
+			$form.submit();
+
+			$form.remove();
+		});
+
+		test('Focus invalid enabled', 2, function () {
+			var $form = $('<form />', {
+					id: 'submitTest'
+				}),
+				$input1,
+				$input2,
+				$input3,
+				$focused;
+
+			$('<input required id="checked-at-submit-1" value="abc123" />')
+				.appendTo($form);
+
+			$('<input required id="checked-at-submit-2" />')
+				.appendTo($form);
+
+			$('<input required id="checked-at-submit-3" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$input3 = $('#checked-at-submit-3');
+
+			// Using default settings
+			$form.h5Validate();
+
+			// Move focus to get a baseline
+			$input3.focus();
+
+			$form.submit();
+
+			$focused = $(':focus');
+			equal($focused.length, 1, 'One element should be focused.');
+			equal($focused.attr('id'), 'checked-at-submit-2', 'The second field is invalid and should be focused.');
+
+			$form.remove();
+		});
+
+		test('Focus invalid disabled', 2, function () {
+			var $form = $('<form />', {
+					id: 'submitTest'
+				}),
+				$input1,
+				$input2,
+				$input3,
+				$focused;
+
+			$('<input required id="checked-at-submit-1" value="abc123" />')
+				.appendTo($form);
+
+			$('<input required id="checked-at-submit-2" />')
+				.appendTo($form);
+
+			$('<input required id="checked-at-submit-3" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$input3 = $('#checked-at-submit-3');
+
+			$form.h5Validate({
+				focusFirstInvalidElementOnSubmit: false
+			});
+
+			// Move focus to get a baseline
+			$input3.focus();
+
+			$form.submit();
+
+			$focused = $(':focus');
+			equal($focused.length, 1, 'One element should be focused.');
+			equal($focused.attr('id'), 'checked-at-submit-3', 'The third field should be still focused.');
+
+			$form.remove();
+		});
+
+		module('Issues');
+
 		test('Issue #29: Disabled fields gum up the works.', function () {
 			var $form = $('<form>', {
 					id: 'disabledTest'


### PR DESCRIPTION
Imitates/emulates the native browser form submit validation procedure of Google Chrome, using h5Validate.
- Prevents the form from submitting if any invalid fields exists.
- Validates all form fields.
- Moves focus to the first invalid field.

The first feature needs to be enabled for the other two (optional) features to execute. All three are enabled by default, see documentation and options. Included a bunch of tests; please execute them to confirm the functionality.
