### PR TITLE
Updated the faulty test for issue #27

### DIFF
--- a/test/test.h5validate.js
+++ b/test/test.h5validate.js
@@ -138,16 +138,32 @@
 		// Validate radio buttons correctly. (Any checked field satisfies required)
 		test('Issue #27: Validate radio buttons correctly.', function () {
 			var $radioTest = $('[name="radio-test"]'),
-				isEmptyValid,
-				isCheckedValid,
+				isEmptyInvalid = true,
+				isCheckedValid = true,
 				$checkme;
-			isEmptyValid = $radioTest.h5Validate('isValid');
+
+			// Perform validation on each of the radio buttons
+			$radioTest.h5Validate('isValid');
+
+			$radioTest.each(function(){
+				// Get validation results without performing validation again
+				isEmptyInvalid = isEmptyInvalid && !$(this).h5Validate('isValid', { revalidate: false });
+			});
+
 			$checkme = $('.checkme');
-			ok(!isEmptyValid, 'Radio should be invalid when empty.');
+			ok(isEmptyInvalid, 'All radio buttons should be invalid when empty.');
 			$checkme.attr('checked', 'checked');
-			isCheckedValid = $checkme.h5Validate('isValid');
+
+			// Call .change() to trigger validation
+			$checkme.change();
+
+			$radioTest.each(function(){
+				// Get validation results without performing validation again
+				isCheckedValid = isCheckedValid && $(this).h5Validate('isValid', { revalidate: false });
+			});
+
 			ok(isCheckedValid,
-				'Radio should be valid as soon as any one is selected');
+				'All radio buttons should be valid as soon as any one is selected');
 		});
 
 		// Todo: test allValid. Make sure to call it more than once and ensure that


### PR DESCRIPTION
I disagree with the previous fix; I believe that it does not fix the problem and that the [included test is faulty](https://github.com/joelpurra/h5Validate/blob/9020fcada80386186cfe687e500d3b1ae8a18872/test/test.h5validate.js#L138) ([original commit](https://github.com/dilvie/h5Validate/commit/7931b05415be53c78eadfea25fd3a2dd2a2a64de#L2R138)).

``` javascript
// Validate radio buttons correctly. (Any checked field satisfies required)
test('Issue #27: Validate radio buttons correctly.', function () {
    var $radioTest = $('[name="radio-test"]'),
        isEmptyValid,
        isCheckedValid,
        $checkme;
    isEmptyValid = $radioTest.h5Validate('isValid');
    $checkme = $('.checkme');
    ok(!isEmptyValid, 'Radio should be invalid when empty.');
    $checkme.attr('checked', 'checked');
    isCheckedValid = $checkme.h5Validate('isValid');
    ok(isCheckedValid,
        'Radio should be valid as soon as any one is selected');
});
```
- The line `isEmptyValid = $radioTest.h5Validate('isValid');` calls `isValid`, which would return the validity for the first element only (see [jsfiddle with .data() called on multiple objects](http://jsfiddle.net/joelpurra/qB8BD/)). (Minor problem, but still a bug.)
-  The line `isCheckedValid = $checkme.h5Validate('isValid');` performs the actual `[required]` validation check and reads the validation result on the only checked element out of the three. The others are, in fact, still invalid according to h5Validate.

This pull request updates the test, but now the tests suite is failing. I'll send another pull request in a second, which fixes the problem.
