### PR TITLE
Validate all radio button with the same name

### DIFF
--- a/jquery.h5validate.js
+++ b/jquery.h5validate.js
@@ -183,6 +183,9 @@
 				var valid = true,
 					formValidity = [],
 					$this = $(this),
+					$allFields,
+					$filteredFields,
+					radioNames = [],
 					getValidity = function getValidity(e, data) {
 						data.e = e;
 						formValidity.push(data);
@@ -197,7 +200,25 @@
 				$this.delegate(settings.allValidSelectors,
 					'validated.allValid', getValidity);
 
-				$this.find(settings.allValidSelectors).each(function () {
+				$allFields = $this.find(settings.allValidSelectors);
+
+				// Filter radio buttons with the same name and keep only one,
+				// since they will be checked as a group by isValid()
+				$filteredFields = $allFields.filter(function(index) {
+					var name;
+
+					if(this.tagName === "INPUT"
+						&& this.type === "radio") {
+						name = this.name;
+						if(radioNames[name] === true) {
+							return false;
+						}
+						radioNames[name] = true;
+					}
+					return true;
+				});
+
+				$filteredFields.each(function () {
 					var $this = $(this);
 					valid = $this.h5Validate('isValid', options) && valid;
 				});

--- a/test/test.h5validate.js
+++ b/test/test.h5validate.js
@@ -202,6 +202,40 @@
 			$form.remove();
 		});
 
+		test('Pull request #39: Each radio button is only validated once in allValid', 3, function () {
+			var $form = $('<form />', {
+					id: 'radio-test3-form'
+				}),
+				$radioTest,
+				isEmptyValid = 0,
+				isCheckedValid = 0,
+				$checkme;
+
+			$('<input type="radio" required id="radio-test3-1" name="radio-test3" value="abc123" />')
+				.appendTo($form);
+
+			$('<input type="radio" required id="radio-test3-2" name="radio-test3" value="def456" />')
+				.appendTo($form);
+
+			$('<input type="radio" required id="radio-test3-3" name="radio-test3" value="ghi789" />')
+				.appendTo($form);
+
+			$form
+				.appendTo('body');
+
+			$form.h5Validate();
+
+			$form.on("validated.radio-test3", function(evt, data){
+				ok(evt.target.name === "radio-test3", "Validated a radio button, " + evt.target.id)
+			});
+
+			$form.h5Validate("allValid");
+
+			$form.off(".radio-test3");
+
+			$form.remove();
+		});
+
 		// Todo: test allValid. Make sure to call it more than once and ensure that
 		// behavior remains consistent.
 	}


### PR DESCRIPTION
This patch fixes radio button validation by validating all radio buttons with the same name (in the same "group") as the current one being validated.

I disagree with the previous fix (see issue #27); I believe that it does not fix the problem. See [pull request #38 "Updated the faulty test for issue #27"](https://github.com/dilvie/h5Validate/pull/38) for an updated test that explains the failing code.

I have kept the [original test for issue #27](https://github.com/joelpurra/h5Validate/blob/ba03859e88f28765d892e0c86727453e445965ec/test/test.h5validate.js#L138). It still passes, but should be patched as it doesn't test validity on all radio buttons in a group being validated.
### Performance note

If anyone is concerned with performance, there might be a better way to perform validation (or just retreive an existing validation result) from the other radio buttons in the same group. Right now each call to validate will trigger validation for the other radio buttons - if there are 3 radio buttons, that means 3 validations. If all 3 radio buttons are being inspected for validation that will mean 9 validations (3 squared). Examples include an externally implemented loop (`$myFields.each(....h5Validate('isValid')`) or in `allValid`. If you have 10 radio buttons, such a loop would mean 100 validations. It should be possible to, for example, internally in `allValid` filter out multiple radio buttons in the same group and just validate one.
