### PR TITLE
Trigger the custom formValidate event before validating a form

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,9 @@
 }</pre></code>
 				</dd>
 
+				<dt><code>formValidate</code></dt>
+				<dd>The form in question is about to be validated. An object is passed with an object containing the property <code>settings</code>, which is a reference to the validation settings in effect.</dd>
+
 				<dt><code>formValidated</code></dt>
 				<dd>The form in question has been validated. An object is passed with an object containing a bool, <code>valid</code>, and an array of validity objects corresponding to the validated elements.</dd>
 			</dl>

--- a/jquery.h5validate.js
+++ b/jquery.h5validate.js
@@ -191,6 +191,8 @@
 
 				options = options || {};
 
+				$this.trigger('formValidate', {settings: $.extend(true, {}, settings)});
+
 				// Make sure we're not triggering handlers more than we need to.
 				$this.undelegate(settings.allValidSelectors,
 					'.allValid', getValidity);

--- a/test/test.h5validate.js
+++ b/test/test.h5validate.js
@@ -86,6 +86,11 @@
 
 			$form.h5Validate();
 
+			$form.bind('formValidate', function (event, data) {
+				ok(data, 'formValidate triggers.');
+				ok(data.settings, 'A copy of the settings is passed.');
+			});
+
 			$input.bind('validated', function (event, data) {
 				ok(data, 'Validated event triggers.');
 				equal(data.element, $input[0], 'Element is correct.');


### PR DESCRIPTION
The `formValidate` even is useful to prepare the form for validation. It complements the `formValidated` event.

I use the formValidate event to unhide certain fields before validation at submission time. The `allValid` call is buried in `.submit(function() ...)` handlers, and I'd like validation and presentation to remain loosely coupled. The fields remain visible if the validation is ok (for the actual form submit via POST) and I hide them again in formValidated if there were validation errors.

_Clarification:_ I'm not talking about `type="hidden"` fields. This is a rather long form, adapted from a paper version, that has been split into section with javascript and css. The backend is a legacy system, and it can only handle a single POST with all the fields at the same time.
