### PR TITLE
Extended phone regex - see below

### DIFF
--- a/jquery.h5validate.js
+++ b/jquery.h5validate.js
@@ -24,7 +24,7 @@
 				// HTML5-compatible validation pattern library that can be extended and/or overriden.
 				patternLibrary : { //** TODO: Test the new regex patterns. Should I apply these to the new input types?
 					// **TODO: password
-					phone: /([\+][0-9]{1,3}([ \.\-])?)?([\(]{1}[0-9]{1,6}[\)])?([0-9A-Za-z \.\-]{1,32})((([Xx]|[Ee][Xx][Tt]|[Ee][Xx][Tt][Ee][Nn][Ss][Ii][Oo][Nn])([ ])?)?[0-9]{1,4}?)/,
+					phone: /([\+][0-9]{1,3}([ \.\-])?)?([\(]{1}[0-9]{1,6}[\)])?([0-9A-Za-z \.\-]{1,32})(([A-Za-z \:]{1,11})?[0-9]{1,4}?)/,
 
 					// Shamelessly lifted from Scott Gonzalez via the Bassistance Validation plugin http://projects.scottsplayground.com/email_address_validation/
 					email: /((([a-zA-Z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-zA-Z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-zA-Z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-zA-Z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-zA-Z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-zA-Z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-zA-Z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-zA-Z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-zA-Z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-zA-Z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?/,

--- a/test/index.html
+++ b/test/index.html
@@ -270,7 +270,7 @@
 		$(document).ready(function () {
 
 			$.h5Validate.addPatterns({
-					phone: /([\+][0-9]{1,3}([ \.\-])?)?([\(]{1}[0-9]{3}[\)])?([0-9A-Z \.\-]{1,32})((x|ext|extension)?[0-9]{1,4}?)/				
+					phone: /([\+][0-9]{1,3}([ \.\-])?)?([\(]{1}[0-9]{1,6}[\)])?([0-9A-Za-z \.\-]{1,32})(([A-Za-z \:]{1,11})?[0-9]{1,4}?)/				
 			});
 		    $('form.h5-defaults').h5Validate();
 			$('#black').h5Validate({

--- a/test/test.h5validate.js
+++ b/test/test.h5validate.js
@@ -267,6 +267,40 @@
 
       $form.empty().remove();
     });
+	
+    test('u01jmg3 Pull Request telephone number regex updated', function () {
+      var $form = $('<form />'),
+        $tel = $('<input type="tel" class="h5-phone" required="required"></input>')
+          .appendTo($form),
+        validValues = ['+441224271234', '+44 (0)1224 271234', '+44 (01224) 27-12-34', '+44 (01224) 27.12.34', 
+		'(01224) 271234 Extension: 1234', '(0)1224 271234 ex 5555'],
+        invalidValues = ['44 (01224) 271234', '01224 271234 (x4444)', '(+44)1224 271234', '(01224) 271234 Extension: #123'],
+        i = validValues.length,
+        j = invalidValues.length,
+        val;
+
+      $form
+        .appendTo('body')
+        .h5Validate();
+
+      while (i) {
+        val = validValues[i-1];
+        $tel.val(val).trigger('keyup');
+        ok($tel.h5Validate('isValid'),
+          'Valid telephone number, ' + val +' should pass validation.');
+        i--;
+      }
+
+      while (j) {
+        val = invalidValues[j-1];
+        $tel.val(val).trigger('keyup');
+        ok(!$tel.h5Validate('isValid'),
+          'Invalid telephone number, ' + val +' should not pass validation.');
+        j--;
+      }
+
+      $form.empty().remove();
+    });	
 
   }
   exports.runTests = runTests;


### PR DESCRIPTION
Added ^ and $ for start and end so surplus chars cause an error
Extended the numbers allowed in brackets to be 6 so (01224) is allowed
Added the optional space so ext 5555 is allowed as well as ext5555
Made the whole thing case insensitive to allow for EXTENSION, etc
