### PR TITLE
Add main field and remove engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "h5validate",
   "main": "jquery.h5validate",
   "version": "0.9.1",
+  "license": "MIT",
   "description": "HTML5 form validation",
   "author": {
     "name": "Eric Elliott",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "h5Validate",
+  "name": "h5validate",
+  "main": "jquery.h5validate",
   "version": "0.9.1",
   "description": "HTML5 form validation",
   "author": {
@@ -25,8 +26,5 @@
   },
   "scripts": {
     "test": "./scripts/test.sh"
-  },
-  "engines": {
-    "node": "~0.x.x"
   }
 }


### PR DESCRIPTION
This:

- lowercases the name of the package in `package.json` to comply with new npm rules re: no capital letters
- adds a main field pointing to the main entry
- removes the engines field since, really, this doesn't work in node, much less 0.x

I know you're working on h5v2 (which is already on npm), but there are plenty of apps currently using this and I figured they'd appreciate it published.

I published 0.9.0 and added you as an owner.